### PR TITLE
ci: automate release

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,8 +22,9 @@ on:
 
   push:
     branches:
-    - master
     - proxy-wasm-spec-0.1.0
+    tags:
+    - '**'
 
 jobs:
 
@@ -105,3 +106,83 @@ jobs:
 
     - name: Package (publish)
       run: cargo +nightly publish --dry-run --target=wasm32-unknown-unknown
+
+  docs:
+    name: "Docs"
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Checkout"
+      uses: actions/checkout@v2
+
+    - name: "Install Rust"
+      run: |
+        rustup update stable
+        rustup default stable
+        rustc -vV
+
+    - name: "Install 'wasm32-unknown-unknown'"
+      run: |
+        rustup target add wasm32-unknown-unknown
+
+    - name: "Build docs"
+      run: |
+        cargo doc --no-deps --target=wasm32-unknown-unknown
+
+    - name: "Publish GitHub Pages"
+      if: ${{ github.event_name == 'push' && github.ref == 'proxy-wasm-spec-0.1.0' }}
+      run: |
+        git fetch origin gh-pages                 # By default, 'actions/checkout' only fetches branch of the commit.
+        git worktree add /tmp/rustdoc gh-pages    # Checkout 'gh-pages' branch into '/tmp/rustdoc'
+        rm -rf /tmp/rustdoc/*                     # Remove all files (except for hidden files, such as .git directory)
+        cp -rp target/doc/* /tmp/rustdoc/
+        cd /tmp/rustdoc
+        git add --all                             # This adds, modifies, and removes index entries to match the working tree.
+        if ! git diff --cached --exit-code ; then # There might be no changes to commit
+          GIT_AUTHOR_NAME="${{ github.event.head_commit.author.name }}" \
+            GIT_AUTHOR_EMAIL="${{ github.event.head_commit.author.email }}" \
+            GIT_AUTHOR_DATE="${{ github.event.head_commit.timestamp }}" \
+            GIT_COMMITTER_NAME="${{ github.event.head_commit.committer.name }}" \
+            GIT_COMMITTER_EMAIL="${{ github.event.head_commit.committer.email }}" \
+            GIT_COMMITTER_DATE="${{ github.event.head_commit.timestamp }}" \
+            git commit -m "${{ github.event.head_commit.message }}"
+          git push origin gh-pages
+        else
+          echo "There are no changes to GitHub Pages."
+        fi
+        git worktree remove --force /tmp/rustdoc  # Remove the working tree.
+
+  publish:
+    name: "Publish Crate"
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+    needs:
+    - stable
+    - nightly
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Checkout"
+      uses: actions/checkout@v2
+
+    - name: "Install Rust"
+      run: |
+        rustup update stable
+        rustup default stable
+        rustc -vV
+
+    - name: "Install 'wasm32-unknown-unknown'"
+      run: |
+        rustup target add wasm32-unknown-unknown
+
+    - name: "Check version"
+      run: |
+        version="$(cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | .version')"
+        tag="${GITHUB_REF##*/}"
+        if [[ "$version" != "$tag" ]]; then
+          echo "Package version according to Cargo.toml ($version) is different from the Git tag ($tag). Did you forget to bump the version in Cargo.toml ?"
+          exit 1
+        fi
+
+    - name: "Publish"
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+      run: |
+        cargo publish --target=wasm32-unknown-unknown

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proxy-wasm-experimental"
-version = "0.1.0-alpha.5"
+version = "0.0.6-alpha1"
 authors = ["Piotr Sikora <piotrsikora@google.com>"]
 description = "WebAssembly for Proxies"
 readme = "README.md"


### PR DESCRIPTION
## Summary

* on commit to `proxy-wasm-spec-0.1.0`,  publish Rust Docs as GitHub Pages
* on tag, publish crate to https://crates.io
* add `#![doc(html_root_url)]
* add version sync tests