### PR TITLE
cleanup for release

### DIFF
--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -284,10 +284,10 @@ impl Dispatcher {
         }
     }
 
-    fn on_downstream_close(&self, context_id: u32, peer_type: PeerType) {
+    fn on_downstream_close(&self, context_id: u32, close_type: CloseType) {
         if let Some(stream) = self.streams.borrow_mut().get_mut(&context_id) {
             self.active_id.set(context_id);
-            stream.on_downstream_close(peer_type)
+            stream.on_downstream_close(close_type)
         } else {
             panic!("invalid context_id")
         }
@@ -302,10 +302,10 @@ impl Dispatcher {
         }
     }
 
-    fn on_upstream_close(&self, context_id: u32, peer_type: PeerType) {
+    fn on_upstream_close(&self, context_id: u32, close_type: CloseType) {
         if let Some(stream) = self.streams.borrow_mut().get_mut(&context_id) {
             self.active_id.set(context_id);
-            stream.on_upstream_close(peer_type)
+            stream.on_upstream_close(close_type)
         } else {
             panic!("invalid context_id")
         }
@@ -458,8 +458,8 @@ pub extern "C" fn proxy_on_downstream_data(
 }
 
 #[no_mangle]
-pub extern "C" fn proxy_on_downstream_connection_close(context_id: u32, peer_type: PeerType) {
-    DISPATCHER.with(|dispatcher| dispatcher.on_downstream_close(context_id, peer_type))
+pub extern "C" fn proxy_on_downstream_connection_close(context_id: u32, close_type: CloseType) {
+    DISPATCHER.with(|dispatcher| dispatcher.on_downstream_close(context_id, close_type))
 }
 
 #[no_mangle]
@@ -472,8 +472,8 @@ pub extern "C" fn proxy_on_upstream_data(
 }
 
 #[no_mangle]
-pub extern "C" fn proxy_on_upstream_connection_close(context_id: u32, peer_type: PeerType) {
-    DISPATCHER.with(|dispatcher| dispatcher.on_upstream_close(context_id, peer_type))
+pub extern "C" fn proxy_on_upstream_connection_close(context_id: u32, close_type: CloseType) {
+    DISPATCHER.with(|dispatcher| dispatcher.on_upstream_close(context_id, close_type))
 }
 
 #[no_mangle]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -145,7 +145,7 @@ pub trait StreamContext: Context {
         hostcalls::get_buffer(BufferType::DownstreamData, start, max_size).unwrap()
     }
 
-    fn on_downstream_close(&mut self, _peer_type: PeerType) {}
+    fn on_downstream_close(&mut self, _close_type: CloseType) {}
 
     fn on_upstream_data(&mut self, _data_size: usize, _end_of_stream: bool) -> Action {
         Action::Continue
@@ -155,7 +155,7 @@ pub trait StreamContext: Context {
         hostcalls::get_buffer(BufferType::UpstreamData, start, max_size).unwrap()
     }
 
-    fn on_upstream_close(&mut self, _peer_type: PeerType) {}
+    fn on_upstream_close(&mut self, _close_type: CloseType) {}
 
     fn on_log(&mut self) {}
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -23,6 +23,7 @@ pub type NewHttpContext = fn(context_id: u32, root_context_id: u32) -> Box<dyn H
 
 #[repr(u32)]
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[non_exhaustive]
 pub enum LogLevel {
     Trace = 0,
     Debug = 1,
@@ -34,6 +35,7 @@ pub enum LogLevel {
 
 #[repr(u32)]
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[non_exhaustive]
 pub enum Action {
     Continue = 0,
     Pause = 1,
@@ -41,6 +43,7 @@ pub enum Action {
 
 #[repr(u32)]
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[non_exhaustive]
 pub enum Status {
     Ok = 0,
     NotFound = 1,
@@ -52,6 +55,7 @@ pub enum Status {
 
 #[repr(u32)]
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[non_exhaustive]
 pub enum BufferType {
     HttpRequestBody = 0,
     HttpResponseBody = 1,
@@ -62,6 +66,7 @@ pub enum BufferType {
 
 #[repr(u32)]
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[non_exhaustive]
 pub enum MapType {
     HttpRequestHeaders = 0,
     HttpRequestTrailers = 1,
@@ -73,7 +78,8 @@ pub enum MapType {
 
 #[repr(u32)]
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-pub enum PeerType {
+#[non_exhaustive]
+pub enum CloseType {
     Unknown = 0,
     Local = 1,
     Remote = 2,


### PR DESCRIPTION
## Summary

* rename `PeerType` into `CloseType` (to match upstream `envoy-wasm`)
* add `#[non_exhaustive]` to avoid backwards-incompatible changes in the future 